### PR TITLE
Disallowing duplicate categories - fixed a category problem w/ editing/adding

### DIFF
--- a/app/src/main/java/com/example/waves_app/CategoryAdapter.java
+++ b/app/src/main/java/com/example/waves_app/CategoryAdapter.java
@@ -131,12 +131,12 @@ public class CategoryAdapter extends RecyclerView.Adapter<CategoryAdapter.ViewHo
                                 e.printStackTrace();
                             }
 
-                            if (newName.length() > 0 && ogName != null && !ogName.equals(newName)) {
+                            if (newName.length() > 0 && ogName != null && !ogName.equals(newName) && !parsedData.contains(newName)) {
                                 // case if the user needs to edit the category
                                 category.setCategoryName(newName);
                                 parsedData.set(pos, newName);
                                 writeCatItems(); // update the persistence
-                            } else if (newName.length() > 0) {
+                            } else if (newName.length() > 0 && !parsedData.contains(newName)) {
                                 // the case if the user is setting category
                                 category.setCategoryName(newName);
                                 parsedData.add(newName);


### PR DESCRIPTION
Fixed the problem of:
1. Hit add category (you either: click it only, don't click it, or type stuff in it)
2. Then, whatever other category you click (besides the new one) will be duplicated as you are changing the focus. (also duplicating still happens if you click stuff then click back on that empty category).

by disallowing duplicates which we wanted anyways